### PR TITLE
feat:일반회원,판매자 로그인,회원가입 및 마이페이지 폼 CSS,JS,JSP 전면적으로 수정 로그인폼 이슈 해결[NOEL-18,19,20,22]

### DIFF
--- a/Final/src/main/webapp/WEB-INF/views/common/marketerHeader.jsp
+++ b/Final/src/main/webapp/WEB-INF/views/common/marketerHeader.jsp
@@ -8,6 +8,12 @@
 			<li>
 				<c:if test="${sessionScope.mk.marketerAuth eq 1}">
 				<div>
+					<a href="/marketerMypage">내 정보 수정</a>
+				</div>
+				<div>
+					<a href="/deleteMarketer?marketerId=${sessionScope.mk.marketerId }" class="delMember">회원 탈퇴</a>
+				</div>
+				<div>
 					<a href="/class/addClassFrm">클래스 등록</a>
 				</div>
 				<div>
@@ -17,23 +23,11 @@
 					<a href="/market/orderManagement">주문 관리</a>
 				</div>
 				</c:if>
-				<div>
-					<a href="/marketerMypage">내 정보 수정</a>
-				</div>
-				<div>
-					<a href="/deleteMarketer?marketerId=${sessionScope.mk.marketerId }" class="delMember">회원 탈퇴</a>
-				</div>
 
 			</li>
 		</ul>
 	</div>
-	<div class="sidebar-2">
-		<ul class="category">
-			<li>
-				<h4>공지사항</h4>
-			</li>
-		</ul>
-	</div>
+
 </aside>
 <script>
 	$(".delMember").on("click", function(e) {

--- a/Final/src/main/webapp/WEB-INF/views/common/memberHeader.jsp
+++ b/Final/src/main/webapp/WEB-INF/views/common/memberHeader.jsp
@@ -7,6 +7,10 @@
         <ul class="category">
             <li>
                 <div>
+                    <a href="/myPage">내 정보 수정</a>
+                    <!-- <a href="/updateMemberFrm.do">내 정보 수정</a> -->
+                </div>
+                <div>
                     <a href="#">예약 내역</a>
                     <!-- <a href="/reserveList.do?reqPage=1">예약 내역</a> -->
                 </div>
@@ -21,27 +25,12 @@
                     <a href="#">Q&A</a>
                 </div>
                 <div>
-                    <a href="/myPage">내 정보 수정</a>
-                    <!-- <a href="/updateMemberFrm.do">내 정보 수정</a> -->
-                </div>
-                <div>
                     <a href="/deleteMember?userId=${sessionScope.m.userId }" class="delMember">회원 탈퇴</a>
                 </div>
             </li>
         </ul>
     </div>
-    <div class="sidebar-2">
-        <ul class="category">
-            <li>
-                <h4>공지사항</h4>
-                <%--    <c:forEach items="${ncList " var="n">
-                      <div class="list-wrap">
-                         <a href="/noticeDetail.do?noticeNo=${n.noticeNo }" class="titleShow">${n.noticeTitle }</a>
-                      </div>
-                   </c:forEach> --%>
-            </li>
-        </ul>
-    </div>
+   
 </aside>
 <script src="https://code.jquery.com/jquery-3.6.1.js"></script>
 

--- a/Final/src/main/webapp/WEB-INF/views/layouts/header.jsp
+++ b/Final/src/main/webapp/WEB-INF/views/layouts/header.jsp
@@ -48,7 +48,7 @@
 							<a class="nav-link" href="/sj">Register</a>
 						</li>
 					</ul>
-
+	
 
 					<!--일반 회원-->
 				</c:when>
@@ -56,7 +56,7 @@
 					<ul class="navbar-nav ms-auto">
 						<c:if test="${sessionScope.m.userLevel eq 1}">
 							<li class="nav-item">
-								<a href="/myPage" class="nav-link" id="font"> ${sessionScope.m.userName }</a>
+								<label class="nav-link" id="font">${sessionScope.m.userName }</label>
 							</li>
 							<li class="nav-item">
 								<a href="/logout" class="nav-link" id="font">Logout</a>
@@ -78,7 +78,7 @@
 								<a href="/logout" class="nav-link" id="font">Logout</a>
 							</li>
 							<li class="nav-item">
-								<a href="memberManage?reqPage=1" class="nav-link" id="font"> adminPage</a>
+								<a href="memberManage?reqPage=1" class="nav-link" id="font"> AdminPage</a>
 							</li>
 						</c:if>
 
@@ -92,7 +92,7 @@
 							</li>
 							<c:if test="${sessionScope.mk.marketerAuth eq 1}">
 								<li class="nav-item">
-									<a class="nav-link" href="/marketerMypage">상품&클래스등록</a>
+									<a class="nav-link" href="/marketerMypage">MY 상품 / 클래스</a>
 								</li>
 							</c:if>
 							<c:if test="${sessionScope.mk.marketerAuth eq 0}">

--- a/Final/src/main/webapp/WEB-INF/views/member/joinFrm.jsp
+++ b/Final/src/main/webapp/WEB-INF/views/member/joinFrm.jsp
@@ -64,6 +64,46 @@
                                 <p class="text-note"></p>
                             </div>
                         </li>
+                        
+                        <li>
+                            <span class="tit">생년월일</span>
+                            <div class="cnt">
+                            	<div>
+                                    <div class="box04" style = "margin-left:0px; margin-right: 10px; width: 240px;">
+                                        <label class="label" for="birth_year">연도를 입력해주세요(숫자만 4자)</label>
+                                        <input type="text" id="birth_year" name="birth_year">
+                                       	<input type="hidden" id="userBirth" name="userBirth">
+                                    </div>
+                                        <div class="selBox01 box01"  >
+                                            <select id="birth_month" name="birth_month" >
+                                                <option value="">월</option>
+                                                <option value="01">1</option>
+                                                <option value="02">2</option>
+                                                <option value="03">3</option>
+                                                <option value="04">4</option>
+                                                <option value="05">5</option>
+                                                <option value="06">6</option>
+                                                <option value="07">7</option>
+                                                <option value="08">8</option>
+                                                <option value="09">9</option>
+                                                <option value="10">10</option>
+                                                <option value="11">11</option>
+                                                <option value="12">12</option>
+                                            </select>
+                                    </div>
+                                    
+                                     <div class="box04" style = "margin-left:10px; margin-right: 0px; width: 230px;">
+                                        <label class="label" for="birth_day">일을 입력해주세요(숫자만 2자)</label>
+                                        <input type="text" id="birth_day" name="birth_day">
+                                         
+                                    </div>
+                                    
+                                    <br>
+                                    <p class="text-note"></p>
+                            	</div>
+                            </div>
+                        </li>
+                        
                         <li>
                             <span class="tit">휴대폰 인증</span>
                             <div class="cnt">
@@ -150,7 +190,6 @@
 			$("[name=contentModal2]").attr("target","contentModal2");
 			$("[name=contentModal2]").submit();
 		});
-		
 		
 	
 		var idFlag = 0;
@@ -273,6 +312,9 @@
 		});
 		
 		/*정규표현식 유효성검사*/
+		
+		 
+	
 		$("#joinBtn").on("click",function(event){
 			//이름 유효성 검사
 			const nameReg = /^[가-힣]{2,5}$/;
@@ -294,7 +336,6 @@
 			const idComment = id.parent().next();
 			if(idReg.test(idValue)){
 				idComment.text("");
-				
 			}else {
 				idComment.text("* 4~20자리 이내로 입력해주세요.");
 				idComment.css("color","red");
@@ -327,6 +368,7 @@
 				event.preventDefault();
 			}
 			
+			//핸드폰 확인
 			var phone1 = $("[name=frontNum]").val();
 			var phone2 = $("[name=memberPhone1]").val();
 			var phone = phone1+phone2;
@@ -341,58 +383,93 @@
 				event.preventDefault();
 			}
 			
+			//생년월일 유효성검사
+			const birthReg = /^(19[0-9][0-9]|20\d{2})-(0[0-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/;
+			var birth_year = $("[name=birth_year]").val();
+			var birth_month = $("[name=birth_month]").val();
+			var birth_day = $("[name=birth_day]").val();
+			var birth = birth_year+"-"+birth_month+"-"+birth_day;
+			$("[name=userBirth]").val(birth);
+			
+			 if(!birth_year){
+			      alert("연도를 입력해주세요");
+			    $("#birth_year").focus();
+			    return false;
+			  }
+			  if(!birth_month){
+			      alert("월을 입력해주세요");
+			    $("#birth_month").focus();
+			    return false;
+			  }
+			  if(!birth_day){
+			      alert("일을 입력해주세요");
+			    $("#birth_day").focus();
+			    return false;
+			  }
+			  if(!birthReg.test(birth)){
+			      alert("생년월일을 형식에 맞게 입력해주세요.");
+			    return false;
+			  }
+			
+			
 		});
+		
+	
 		
        
 		
 		
 			
-		
-		$("input").on("focus",function(){
-		    const label = $(this).prev();
-		    label.css("display","none");
-		});
-		$("input").on("blur",function(){
-		    const label = $(this).prev();
-		    if($(this).val() == ""){
-			    label.css("display","");
-		    }
-		});
+	const Jinput01 = $(".label").next();
+	Jinput01.on("focus",function(){
+	    const label = $(this).prev();
+	    label.css("display","none");
+	});
+	Jinput01.on("blur",function(){
+	    const label = $(this).prev();
+	    if($(this).val() == ""){
+		    label.css("display","");
+	    }
+	});
 		$(".phoneChkSendBtn").on("mouseover",function(){
-			$(this).css("background-color","rgb(97, 76, 76)");
+			$(this).css("background-color","#d15662");
 			$(this).css("border","1px solid black");
-			$(this).css("color","#ffc107");
+			$(this).css("color","rgb(255, 255, 255)");
 		})
 		$(".phoneChkSendBtn").on("mouseleave",function(){
 			$(this).css("background-color","");
+			$(this).css("border","");
 			$(this).css("color","");
 		})
         $(".phoneChkBtn").on("mouseover",function(){
-			$(this).css("background-color","rgb(97, 76, 76)");
+			$(this).css("background-color","#d15662");
 			$(this).css("border","1px solid black");
-			$(this).css("color","#ffc107");
+			$(this).css("color","rgb(255, 255, 255)");
 		})
 		$(".phoneChkBtn").on("mouseleave",function(){
 			$(this).css("background-color","");
+			$(this).css("border","");
 			$(this).css("color","");
 		})
 		$("#idChkBtn").on("mouseover",function(){
-			$(this).css("background-color","rgb(97, 76, 76)");
+			$(this).css("background-color","#d15662");
 			$(this).css("border","1px solid black");
-			$(this).css("color","#ffc107");
+			$(this).css("color","rgb(255, 255, 255)");
 		})
 		$("#idChkBtn").on("mouseleave",function(){
 			$(this).css("background-color","");
+			$(this).css("border","");
 			$(this).css("color","");
 		})
 		const joinBtn = $(".joinBtn").children();
 		$("#joinBtn").on("mouseover",function(){
-			$(this).css("background-color","rgb(97, 76, 76)");
+			$(this).css("background-color","#d15662");
 			$(this).css("border","1px solid black");
-			$(this).css("color","#ffc107");
+			$(this).css("color","rgb(255, 255, 255)");
 		})
 		$("#joinBtn").on("mouseleave",function(){
 			joinBtn.css("background-color","");
+			$(this).css("border","");
 			$(this).css("color","");
 		})
 		

--- a/Final/src/main/webapp/WEB-INF/views/member/loginFrm.jsp
+++ b/Final/src/main/webapp/WEB-INF/views/member/loginFrm.jsp
@@ -35,15 +35,15 @@
                         <li>         
                             <div class="Linput01">
                                 <div>
-                                    <label class="Llabel" for="memberId">아이디</label>
-                                    <input type="text" name="userId" id="memberId">
+                                    <label class="Llabel" for="userId">아이디</label>
+                                    <input type="text" name="userId" class="userId">
                                 </div>
                             </div>                
                         </li>
                         <li>
                             <div class="Linput01">
-                                <label class="Llabel" for="memberPw">비밀번호</label>
-                                <input type="password" name="userPw" id="memberPw">
+                                <label class="Llabel" for="userPw">비밀번호</label>
+                                <input type="password" name="userPw" class="userPw">
                             </div>
                         </li>
                         <button class="login-btn" type="submit">로그인</button>
@@ -90,13 +90,13 @@
     <script>
         const input = $(".Llabel").next();
         input.on("focus",function(){
-		    const label = $(this).prev();
-		    label.css("display","none");
+		    const Llabel = $(this).prev();
+		    Llabel.css("display","none");
 		});
 		input.on("blur",function(){
-		    const label = $(this).prev();
+		    const Llabel = $(this).prev();
 		    if($(this).val() == ""){
-			    label.css("display","");
+			    Llabel.css("display","");
 		    }
 		});
 		
@@ -136,9 +136,9 @@
 		
 		$(".login-btn").on("click",function(e){
 			if(selLogin == 1) {
-				var memberId = $("#memberId").val();
-				var memberPw = $("#memberPw").val();
-				if(memberId == "" || memberPw == "") {
+				var userId = $("#userId").val();
+				var userPw = $("#userPw").val();
+				if(userId == "" || userPw == "") {
 					alert("정보를 입력해주세요.");
 					e.preventDefault();
 				}

--- a/Final/src/main/webapp/WEB-INF/views/member/marketerJoinFrm.jsp
+++ b/Final/src/main/webapp/WEB-INF/views/member/marketerJoinFrm.jsp
@@ -68,12 +68,13 @@
                             <span class="tit">이메일</span>
                             <div class="cnt">
                             	<div>
-                                    <div class="box04" style = "margin-left:0px; margin-right: 10px">
+                                    <div class="box04" style = "margin-left:0px; margin-right: 10px; ">
                                         <label class="label" for="email">이메일 아이디를 입력해주세요</label>
                                         <input type="text" id="email" name="email">
                                         <input type="hidden" id="marketerEmail" name="marketerEmail">
                                     </div>
-                                        <div class="selBox01 box01" >
+                                    	<div style ="margin-right: 10px; float: left; font-size: 20px">@</div>
+                                        <div class="selBox01 box01"  >
                                             <select id="email_domain" >
                                                 <option value="naver.com">naver.com</option>
 											    <option value="gmail.com">gmail.com</option>
@@ -368,11 +369,11 @@
 			}
 			
 			// 이메일 유효성 검사
-			var email_rule =  /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+			var email_rule =  /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/;
 			  var email =$("#email").val();
 			  var email_domain =$("#email_domain").val();
 			  var mail = email+"@"+email_domain;
-			  $("[name=marketerEmail]").val(mail);  ;
+			  $("[name=marketerEmail]").val(mail);
 			 
 			  if(!marketerEmail){
 			      alert("이메일을 입력해주세요");
@@ -384,59 +385,63 @@
 			    $("#email_domain").focus();
 			    return false;
 			  }
-			  
-			  
 			  if(!email_rule.test(mail)){
 			      alert("이메일을 형식에 맞게 입력해주세요.");
 			    return false;
 			  }
 			  
 		});
-		$("input").on("focus",function(){
+		
+		const Jinput01 = $(".label").next();
+		Jinput01.on("focus",function(){
 		    const label = $(this).prev();
 		    label.css("display","none");
 		});
-		$("input").on("blur",function(){
+		Jinput01.on("blur",function(){
 		    const label = $(this).prev();
 		    if($(this).val() == ""){
 			    label.css("display","");
 		    }
 		});
 		$(".phoneChkSendBtn").on("mouseover",function(){
-			$(this).css("background-color","rgb(97, 76, 76)");
+			$(this).css("background-color","#d15662");
 			$(this).css("border","1px solid black");
-			$(this).css("color","#ffc107");
+			$(this).css("color","rgb(255, 255, 255)");
 		})
 		$(".phoneChkSendBtn").on("mouseleave",function(){
 			$(this).css("background-color","");
+			$(this).css("border","");
 			$(this).css("color","");
 		})
         $(".phoneChkBtn").on("mouseover",function(){
-			$(this).css("background-color","rgb(97, 76, 76)");
+        	$(this).css("background-color","#d15662");
 			$(this).css("border","1px solid black");
-			$(this).css("color","#ffc107");
+			$(this).css("color","rgb(255, 255, 255)");
 		})
 		$(".phoneChkBtn").on("mouseleave",function(){
 			$(this).css("background-color","");
+			$(this).css("border","");
 			$(this).css("color","");
 		})
 		$("#idChkBtn").on("mouseover",function(){
-			$(this).css("background-color","rgb(97, 76, 76)");
+			$(this).css("background-color","#d15662");
 			$(this).css("border","1px solid black");
-			$(this).css("color","#ffc107");
+			$(this).css("color","rgb(255, 255, 255)");
 		})
 		$("#idChkBtn").on("mouseleave",function(){
 			$(this).css("background-color","");
+			$(this).css("border","");
 			$(this).css("color","");
 		})
 		const joinBtn = $(".joinBtn").children();
 		$("#joinBtn").on("mouseover",function(){
-			$(this).css("background-color","rgb(97, 76, 76)");
+			$(this).css("background-color","#d15662");
 			$(this).css("border","1px solid black");
-			$(this).css("color","#ffc107");
+			$(this).css("color","rgb(255, 255, 255)");
 		})
 		$("#joinBtn").on("mouseleave",function(){
 			joinBtn.css("background-color","");
+			$(this).css("border","");
 			$(this).css("color","");
 		})
 		

--- a/Final/src/main/webapp/WEB-INF/views/member/marketerMypage.jsp
+++ b/Final/src/main/webapp/WEB-INF/views/member/marketerMypage.jsp
@@ -24,7 +24,7 @@
 					<input type="hidden" name="marketerId" value="${sessionScope.mk.marketerId }">
 					<div class="membership-form">
 						<div class="form-write">
-							<h4>회원 정보</h4>
+							<h4>회원 정보 수정</h4>
 							<ul>
 								<li>
 									<span class="tit">이름</span>

--- a/Final/src/main/webapp/resources/css/header/style.css
+++ b/Final/src/main/webapp/resources/css/header/style.css
@@ -198,8 +198,8 @@ section {
 
 .btn-brand {
     border-color:  #dc3545;
-    background-color: #fff;
-    color: #dc3545;
+    background-color: #dc3545;
+    color: #fff;
 }
 
 .btn-brand1 {
@@ -218,7 +218,7 @@ section {
 }
 
 .btn-brand:hover {
-    background-color: #dc3545;
+    background-color: #d15662;
     border-color: #d15662;
     color: rgb(255, 255, 255);
 }

--- a/Final/src/main/webapp/resources/css/joinFrm.css
+++ b/Final/src/main/webapp/resources/css/joinFrm.css
@@ -74,7 +74,7 @@ input {
     top: 0;
     height: 38px;
     width: 103px;
-    background-color: rgb(51,51,51);
+    background-color: #dc3545;
     color: #fff;
     border: none;
     transition: 0.5s;
@@ -138,7 +138,7 @@ input {
     height: 36px;
     width: 98px;
     margin-left: 10px;
-    background-color: rgb(51,51,51);
+    background-color: #dc3545;
     color: #fff;
     border: none;
     font-size: 14px;
@@ -166,11 +166,13 @@ input {
     margin-top: 10px;
     width: 70px;
     height: 38px;
-    background-color: rgb(51,51,51);
+    background-color: #dc3545;
     color: #fff;
     border: none;
     transition: 0.5s;
 }
+
+
 
 .agreeChkBox-wrap{
     border-top: 1px solid #d7d7d7;
@@ -205,6 +207,12 @@ hr{
 .allowContent{
     float: right;
 }
+
+input[type="checkbox" i]:checked {
+    accent-color: #dc3545;	 ;
+
+}
+
 .joinBtn{
     text-align: center;
 }
@@ -212,7 +220,7 @@ hr{
     width: 300px;
     height: 40px;
     margin: 0 auto;
-    background-color: rgb(51,51,51);
+    background-color:#dc3545;
     color: #fff;
     border: none;
     transition: 0.5s;

--- a/Final/src/main/webapp/resources/css/loginFrm.css
+++ b/Final/src/main/webapp/resources/css/loginFrm.css
@@ -25,7 +25,8 @@
 
 input[type='radio'],
 input[type='radio']:checked {
-    appearance: none;
+    
+    accent-color: #dc3545;
     width: 0.9rem;
     height: 0.9rem;
     border-radius: 100%;
@@ -38,7 +39,8 @@ input[type='radio'] {
 }
 
 input[type='radio']:checked {
-    background-color: rgb(51, 51, 51);
+    background-color: #dc3545;
+    border: 1px solid #dc3545;
 }
 
 

--- a/Final/src/main/webapp/resources/css/member/marketer.css
+++ b/Final/src/main/webapp/resources/css/member/marketer.css
@@ -8,7 +8,7 @@
 }
 /*업주 마이페이지*/
 .content-wrap{
-	height: 1570px;
+	height: 900px;
 	width: 1100px;
 	min-width: 850px;
 	margin: 35px auto;

--- a/Final/src/main/webapp/resources/css/member/memberHeader.css
+++ b/Final/src/main/webapp/resources/css/member/memberHeader.css
@@ -8,7 +8,7 @@
 }
 /*업주 마이페이지*/
 .content-wrap{
-    height: 1570px;
+    height: 900px;
     width: 1100px;
     min-width: 850px;
     margin: 35px auto;

--- a/Final/src/main/webapp/resources/css/member/updateMarketer.css
+++ b/Final/src/main/webapp/resources/css/member/updateMarketer.css
@@ -7,14 +7,16 @@
 }
 .form-write>h4{
     padding-top: 12px;
-    text-align: center;
-    margin-left: 20px;
+    padding-bottom: 12px;
+    padding-left : 15px;
+    border-bottom: 2px solid #000;
 }
 .membership-form>.form-write>ul li{
     list-style: none;
 }
 .contents{
     width: 800px;
+    padding-top: 30px;
     margin: 0 auto 40px;
 }
 .form-write>ul{

--- a/Final/src/main/webapp/resources/css/member/updateOwner.css
+++ b/Final/src/main/webapp/resources/css/member/updateOwner.css
@@ -7,6 +7,7 @@
 }
 .form-write>h4{
     padding-bottom: 12px;
+    padding-left : 15px;	
     border-bottom: 2px solid #000;
 }
 .membership-form>.form-write>ul li{
@@ -14,7 +15,7 @@
 }
 .contents{
     width: 800px;
-    padding-top: 10px;
+    padding-top: 30px;
     margin: 0 auto 40px;
 }
 .form-write>ul{


### PR DESCRIPTION
1/2
1. 메인화면 class market 버튼색 변경 완료 [NOEL-18]
2. 본인(현오) 서버에서는 약관 내용 클릭시 팝업창 정상적으로 중앙에 뜸
3. 회원 가입 버튼 색 변경 완료 [NOEL-19]
4. 체크박스 체크시 버튼 색 변경 완료[NOEL-19]
5. 판매자 회원가입 폼에 이메일 부분 @ 추가 완료[NOEL-19]
6.로그인 폼 라디오 박스 색상 변경 완료[NOEL-20]

1/3
1. 일반회원 회원가입 생년월일 넣기[NOEL-19]
2.*이슈* 회원가입 페이지에서 로그인시 사업자를 클릭하면
일반회원이 사라짐 해결[NOEL-20]

1/4
1. 회원정보 수정 : 높이 900px; 수정 완료 memberheader.css수정[NOEL-22]
2. 공지사항 div 삭제 jsp 수정[NOEL-22]
3. 헤더 : ' MY 상품 / 클래스 ' 로 변경완료[NOEL-22]
4. 일반회원, 판매자 mypage[NOEL-22]
'회원 정보 수정' margin 줄 것 → 내 정보 수정 탭을 제일 위로 위치 변경완료
updateOwner.css 수정